### PR TITLE
뿌리오 배포 준비 main에 병합 요청

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+android/
+ios/
+linux/
+macos/
+windows/
+.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:latest AS build
+# Flutter SDK를 설치하기 위한 필수 도구 설치
+
+RUN apt-get update &&\
+    apt-get install -y --no-install-recommends \
+    ca-certificates git unzip curl xz-utils libglu1-mesa zip &&\
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/local
+RUN git clone https://github.com/flutter/flutter.git -b stable --depth 1 flutter
+ENV PATH="${PATH}:/usr/local/flutter/bin:/usr/local/flutter/bin/cache/dart-sdk/bin"
+RUN flutter doctor
+
+WORKDIR /app
+COPY . .
+RUN echo 'const address = "localhost:8080";' > lib/const/server_address.dart
+RUN flutter pub get
+RUN flutter build web
+
+# NGINX 설정
+FROM nginx:alpine
+COPY --from=build  /app/build/web /usr/share/nginx/html
+COPY ./nginx.conf /etc/nginx/nginx.conf
+
+# NGINX를 실행
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/lib/authentication/sign_in_logic.dart
+++ b/lib/authentication/sign_in_logic.dart
@@ -6,7 +6,7 @@ import 'package:precapstone/const/server_address.dart';
 class AuthService {
   // 로그인 함수
   Future<bool> login(String email, String password) async {
-    final url = Uri.parse('http://$address:3000/v1/signIn');
+    final url = Uri.parse('http://$address/v1/signIn');
 
     try {
       final response = await http.post(

--- a/lib/const/server_address.dart
+++ b/lib/const/server_address.dart
@@ -1,1 +1,1 @@
-const address = "192.168.4.21";
+const address = "localhost:3000";

--- a/lib/message_record/record_query_screen.dart
+++ b/lib/message_record/record_query_screen.dart
@@ -39,7 +39,7 @@ class _RecordQueryPageState extends State<RecordQueryPage> {
       }
 
       final response = await http.get(
-        Uri.parse('http://$address:3000/v1/message'),
+        Uri.parse('http://$address/v1/message'),
         headers: {
           'Authorization': 'Bearer $token',
         },
@@ -52,7 +52,7 @@ class _RecordQueryPageState extends State<RecordQueryPage> {
           messages = data['messages'] as List;
 
           imageUrls = messages
-              .map((item) => 'http://$address:3000${item["image"]}')
+              .map((item) => 'http://$address${item["image"]}')
               .toList();
 
           messageContents = messages
@@ -79,7 +79,7 @@ class _RecordQueryPageState extends State<RecordQueryPage> {
   }
 
   Future<void> deleteQuery(int index) async {
-    final url = Uri.parse('http://$address:3000/v1/message/$index');
+    final url = Uri.parse('http://$address/v1/message/$index');
 
     try {
       // SharedPreferences에서 토큰 가져오기
@@ -168,7 +168,7 @@ class _RecordQueryPageState extends State<RecordQueryPage> {
                                       // 동기화된 리스트도 업데이트
                                       imageUrls = messages
                                           .map((item) =>
-                                              'http://$address:3000${item["image"]}')
+                                              'http://$address${item["image"]}')
                                           .toList();
                                       messageContents = messages
                                           .map((item) => item["messageJson"]

--- a/lib/send_message/check_image_screen.dart
+++ b/lib/send_message/check_image_screen.dart
@@ -46,7 +46,7 @@ class _CheckImagePageState extends State<CheckImagePage> {
                       ),
                       child: Center(
                         child: Image.network(
-                          'http://$address:3000$currentImgUrl',
+                          'http://$address$currentImgUrl',
                           fit: BoxFit.cover,
                           loadingBuilder: (BuildContext context, Widget child,
                               ImageChunkEvent? loadingProgress) {

--- a/lib/send_message/create_image_screen.dart
+++ b/lib/send_message/create_image_screen.dart
@@ -36,7 +36,7 @@ class _CreateImagePageState extends State<CreateImagePage> {
       TextEditingController();
 
   Future<void> sendDataAndNavigate() async {
-    final url = Uri.parse('http://$address:3000/v1/image');
+    final url = Uri.parse('http://$address/v1/image');
     final category = bookCategoryController.text;
     final intro = bookIntroductionController.text;
 

--- a/lib/send_message/input_phone_number_screen.dart
+++ b/lib/send_message/input_phone_number_screen.dart
@@ -29,7 +29,7 @@ class _InputPhoneNumberPageState extends State<InputPhoneNumberPage> {
   final TextEditingController receiverController = TextEditingController();
 
   Future<void> sendMessage() async {
-    final url = Uri.parse('http://$address:3000/v1/message');
+    final url = Uri.parse('http://$address/v1/message');
 
     if (currentSender == '') {
       ScaffoldMessenger.of(context).showSnackBar(

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,26 @@
+events {}
+
+http {
+    server {
+        listen 80;
+
+        location / {
+            root /usr/share/nginx/html;
+            try_files $uri $uri/ /index.html;
+        }
+
+        location /images/ {
+            proxy_pass http://backend:3000;
+            proxy_set_header X-Forwarded-Host $host:$server_port;
+            proxy_set_header X-Forwarded-Server $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /v1/ {
+            proxy_pass http://backend:3000;
+            proxy_set_header X-Forwarded-Host $host:$server_port;
+            proxy_set_header X-Forwarded-Server $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+    }
+}


### PR DESCRIPTION
`server_address.dart`에 주소 변수를 `localhost:3000`으로 변경. 포트 번호를 포함하게 변경했고, 이 변수를 사용하는 다른 코드들에서는 포트 번호를 빼게끔 수정함.

예시) `Uri.parse('http://$address:3000/v1/signIn');` 에서 `Uri.parse('http://$address/v1/signIn');` 로 변경.

이외에 도커 관련 스크립트 추가함.